### PR TITLE
Add simple propagation step testbench

### DIFF
--- a/propagation_kernel_v1/step_propagators_tb.cpp
+++ b/propagation_kernel_v1/step_propagators_tb.cpp
@@ -1,0 +1,45 @@
+#include "step_propagators.h"
+#include <complex>
+#include <cstdio>
+#include <cmath>
+
+static void read_complex_matrix(const char* fn, complex_t M[DIM][DIM]) {
+    FILE* f = std::fopen(fn, "r");
+    if (!f) {
+        std::perror("fopen");
+        std::exit(1);
+    }
+    for (int j = 0; j < DIM; ++j)
+        for (int i = 0; i < DIM; ++i) {
+            float re, im;
+            std::fscanf(f, "%f %f", &re, &im);
+            M[i][j] = complex_t{re, im};
+        }
+    std::fclose(f);
+}
+
+static float compare_matrices(const complex_t A[DIM][DIM], const complex_t B[DIM][DIM]) {
+    double sum_sq = 0.0;
+    for (int j = 0; j < DIM; ++j)
+        for (int i = 0; i < DIM; ++i) {
+            float dre = A[i][j].real() - B[i][j].real();
+            float dim = A[i][j].imag() - B[i][j].imag();
+            sum_sq += double(dre*dre + dim*dim);
+        }
+    return std::sqrt(sum_sq / double(DIM*DIM));
+}
+
+int main() {
+    static complex_t phi_in[DIM][DIM];
+    static complex_t phi_out[DIM][DIM];
+    static complex_t phi_ref[DIM][DIM];
+
+    read_complex_matrix("propagation_kernel_v1/validationData/full_step_within_tissue/initial_field.dat", phi_in);
+    read_complex_matrix("propagation_kernel_v1/validationData/full_step_within_tissue/full_step_within_tissue_step_1.dat", phi_ref);
+
+    propagation_step(phi_in, phi_out);
+
+    float rms = compare_matrices(phi_out, phi_ref);
+    std::printf("RMS error: %e\n", rms);
+    return (rms < 1e-3f) ? 0 : 1;
+}

--- a/propagation_kernel_v1/test_utils.h
+++ b/propagation_kernel_v1/test_utils.h
@@ -4,7 +4,7 @@
 
 #include <complex>
 #include <cstdio>
-#include "bpm_split_step.h"   // defines DIM
+#include "step_propagators.h"   // defines DIM
 #include <hls_x_complex.h>     // defines hls::x_complex
 
 // Print the top-left maxR×maxC block of a DIM×DIM complex matrix


### PR DESCRIPTION
## Summary
- update test utilities to rely on current headers
- add `step_propagators_tb.cpp` to test `propagation_step`

## Testing
- `g++ -std=c++17 propagation_kernel_v1/step_propagators.cpp propagation_kernel_v1/test_utils.cpp propagation_kernel_v1/step_propagators_tb.cpp -o propagation_kernel_v1/step_propagators_tb` *(fails: `hls_x_complex.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68740576a6b48332bb0ba4dd5de309cd