### PR TITLE
Fix undefined constants for HLS build

### DIFF
--- a/propagation_kernel_v1/bpm_prop_accel.cpp
+++ b/propagation_kernel_v1/bpm_prop_accel.cpp
@@ -1,6 +1,16 @@
 #include "step_propagators.h"
 #include <ap_int.h>
 
+// Size of one DIM x DIM complex matrix used by the AXI interfaces
+#ifndef MATRIX_SIZE
+#define MATRIX_SIZE (DIM*DIM)
+#endif
+
+// Number of propagation steps along the Z axis
+#ifndef Nz
+#define Nz 120
+#endif
+
 
 extern "C" {
 


### PR DESCRIPTION
## Summary
- add default values for `MATRIX_SIZE` and `Nz` so bpm_prop_accel.cpp builds

## Testing
- `g++ -std=c++17 propagation_kernel_v1/step_propagators.cpp propagation_kernel_v1/test_utils.cpp propagation_kernel_v1/step_propagators_tb.cpp -o step_propagators_tb`
- `timeout 12 ./step_propagators_tb`

------
https://chatgpt.com/codex/tasks/task_e_68741f4227708332a1fca784ee802d61