### PR TITLE
Remove legacy half-step kernels

### DIFF
--- a/propagation_kernel_v1/hls_stub.h
+++ b/propagation_kernel_v1/hls_stub.h
@@ -3,9 +3,22 @@
 #define HLS_STUB_H
 #include <complex>
 #include <cmath>
+#include <queue>
 namespace hls {
 template<typename T>
 using x_complex = std::complex<T>;
+
+// ---------------------------------------------------------------------
+// Minimal hls::stream stub used for host compilation
+// ---------------------------------------------------------------------
+template<typename T>
+class stream {
+    std::queue<T> q;
+public:
+    inline bool empty() const { return q.empty(); }
+    inline void write(const T& v) { q.push(v); }
+    inline T read() { T v = q.front(); q.pop(); return v; }
+};
 
 inline float exp(float x) { return std::exp(x); }
 inline double exp(double x) { return std::exp(x); }

--- a/propagation_kernel_v1/step_propagators.h
+++ b/propagation_kernel_v1/step_propagators.h
@@ -5,6 +5,7 @@
 #if __has_include(<hls_x_complex.h>)
 #  include <hls_x_complex.h>
 #  include <hls_math.h>
+#  include <hls_stream.h>
 #else
 #  include "hls_stub.h"
 #endif
@@ -70,28 +71,13 @@ void adi_y(
     complex_t phi_inter[DIM][DIM]  // Campo intermedio
 );
 
-/**
- * Aplica el efecto no lineal Kerr (half-step).
- */
-void half_nonlinear(
-    complex_t phi[DIM],      // Campo de entrada
-    complex_t phi_out[DIM]   // Campo de salida
-);
 
 /**
- * Aplica absorción lineal (half-step).
+ * Streaming version applying TPA, Kerr and linear attenuation.
  */
-void half_linear_absorption(
-    complex_t phi[DIM],      // Campo de entrada
-    complex_t phi_out[DIM]   // Campo de salida
-);
-
-/**
- * Aplica absorción de dos fotones (half-step).
- */
-void half_2photon_absorption(
-    complex_t phi[DIM],      // Campo de entrada
-    complex_t phi_out[DIM]   // Campo de salida
+void half_nonlin_ops(
+    hls::stream<complex_t>& in,
+    hls::stream<complex_t>& out
 );
 
 /**

--- a/propagation_kernel_v1/step_propagators_tb.cpp
+++ b/propagation_kernel_v1/step_propagators_tb.cpp
@@ -133,6 +133,15 @@ static void run_half_test(const char* name,
     else             std::printf("  [OK]\n");
 }
 
+static void half_nonlin_ops_array(complex_t in[DIM], complex_t out[DIM]) {
+    hls::stream<complex_t> s_in, s_out;
+    for (int i = 0; i < DIM; ++i) {
+        s_in.write(in[i]);
+        half_nonlin_ops(s_in, s_out);
+        out[i] = s_out.read();
+    }
+}
+
 static void run_full_step(const char* name,
                           const char* init_file,
                           const char* ref_file,
@@ -230,20 +239,11 @@ int main() {
                  "C:\\Vws\\z_scan_acceleration_ovr\\propagation_kernel_v1\\validationData\\in.dat",
                  "C:\\Vws\\z_scan_acceleration_ovr\\propagation_kernel_v1\\validationData\\adi_y_out.dat");
 
-    run_half_test("Half nonlinear",
-                  half_nonlinear,
-                  "C:\\Vws\\z_scan_acceleration_ovr\\propagation_kernel_v1\\validationData\\in.dat",
-                  "C:\\Vws\\z_scan_acceleration_ovr\\propagation_kernel_v1\\validationData\\half_nonlinear_out.dat");
-
-    run_half_test("Half linear absorption",
-                  half_linear_absorption,
-                  "C:\\Vws\\z_scan_acceleration_ovr\\propagation_kernel_v1\\validationData\\in.dat",
-                  "C:\\Vws\\z_scan_acceleration_ovr\\propagation_kernel_v1\\validationData\\half_linear_absorption_out.dat");
-
-    run_half_test("Half 2-photon absorption",
-                  half_2photon_absorption,
+    run_half_test("Half nonlin ops",
+                  half_nonlin_ops_array,
                   "C:\\Vws\\z_scan_acceleration_ovr\\propagation_kernel_v1\\validationData\\in.dat",
                   "C:\\Vws\\z_scan_acceleration_ovr\\propagation_kernel_v1\\validationData\\half_2photon_absorption_out.dat");
+
 
     run_bvec_test("compute_b_vector",
                   "C:\\Vws\\z_scan_acceleration_ovr\\propagation_kernel_v1\\validationData\\thomas\\bvec_x0.dat",


### PR DESCRIPTION
## Summary
- drop old per-operator half-step functions
- add array wrapper for streaming non-linear operator in tests
- pipe ADI results through streaming kernel

## Testing
- `g++ -std=c++17 -I propagation_kernel_v1 propagation_kernel_v1/step_propagators_tb.cpp propagation_kernel_v1/step_propagators.cpp propagation_kernel_v1/test_utils.cpp -o step_propagators_tb.exe`
- `./step_propagators_tb.exe` *(fails: fopen: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6876c72169e88332aa201abf1c35d7fc